### PR TITLE
Use release profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,23 @@ implementation 'com.sinch:sdk-sms:1.1.0'
 This project uses the Maven build tool, and the typical Maven goals are supported. To install the package to your local
 Maven repository it therefore is sufficient to execute.
 
-```javascript
+```bash
 git clone https://github.com/sinch/sinch-java-sms.git
 cd sinch-java-sms    
 mvn clean install
 ```
 
 Build .jar file
-
-    $ mvn package
+```bash
+mvn package
+```
 
 It will give you `sdk-sms-1.0.7-jar-with-dependencies.jar`
 
 To skip local test
-
-    $ mvn package -Dmaven.test.skip=true
+```bash
+mvn package -Dmaven.test.skip=true
+```
 
 in your terminal. The project will then be compiled and tested before finally being installed in your local repository.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ scheduled sends, organizing your frequent recipients into groups, and customizin
 parameterization. It offers an asynchronous Java API that provides convenient access to all the features of the SMS REST
 API.
 
+API reference: https://developers.sinch.com/docs/sms/api-reference
+
 ### The library is compatible with Java 8 and later.
 
 ## Using
@@ -74,6 +76,8 @@ MtBatchTextSmsResult batch = conn.createBatch(
 
 System.out.println("Successfully sent batch " + batch.id());
 ```
+
+Please visit https://developers.sinch.com/docs/sms/getting-started/java/send-sms-with-java/ for more detailed instructions.
 
 ## Building and installing
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,12 @@ We recommend enabling annotation processing in your IDE https://immutables.githu
 ### Set up Api Client
 
 ```java
+String servicePlanId = "SERVICE_PLAN_ID";
+String token = "SERVICE_TOKEN";
 ApiConnection conn =
     ApiConnection.builder()
-        .servicePlanId("SERVICE_PLAN_ID")
-        .token("SERVICE_TOKEN")
+        .servicePlanId(servicePlanId)
+        .token(token)
         .start();
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,15 +52,7 @@ mvn package -Dmaven.test.skip=true
 
 in your terminal. The project will then be compiled and tested before finally being installed in your local repository.
 
-## Developing in Eclipse
-
-To import the project into Eclipse it is necessary to install the m2e plugin and the m2e-apt connector. Both are
-available at the Eclipse Marketplace. Before importing the project ensure that automatic configuration of JDT APT is
-enabled. The Immutables website has
-[good instructions](https://immutables.github.io/apt.html#eclipse)
-with screenshots.
-
-After this initial setup development in Eclipse should be reasonably straight forward.
+We recommend enabling annotation processing in your IDE https://immutables.github.io/apt.html.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -27,33 +27,6 @@ Gradle
 implementation 'com.sinch:sdk-sms:1.1.0'
 ```
 
-## Building and installing
-
-This project uses the Maven build tool, and the typical Maven goals are supported. To install the package to your local
-Maven repository it therefore is sufficient to execute.
-
-```bash
-git clone https://github.com/sinch/sinch-java-sms.git
-cd sinch-java-sms    
-mvn clean install
-```
-
-Build .jar file
-```bash
-mvn package
-```
-
-It will give you `sdk-sms-1.0.7-jar-with-dependencies.jar`
-
-To skip local test
-```bash
-mvn package -Dmaven.test.skip=true
-```
-
-in your terminal. The project will then be compiled and tested before finally being installed in your local repository.
-
-We recommend enabling annotation processing in your IDE https://immutables.github.io/apt.html.
-
 ## Quick Start
 
 ### Set up Api Client
@@ -101,6 +74,33 @@ MtBatchTextSmsResult batch = conn.createBatch(
 
 System.out.println("Successfully sent batch " + batch.id());
 ```
+
+## Building and installing
+
+This project uses the Maven build tool, and the typical Maven goals are supported. To install the package to your local
+Maven repository it therefore is sufficient to execute.
+
+```bash
+git clone https://github.com/sinch/sinch-java-sms.git
+cd sinch-java-sms    
+mvn clean install
+```
+
+Build .jar file
+```bash
+mvn package
+```
+
+It will give you `sdk-sms-1.0.7-jar-with-dependencies.jar`
+
+To skip local test
+```bash
+mvn package -Dmaven.test.skip=true
+```
+
+in your terminal. The project will then be compiled and tested before finally being installed in your local repository.
+
+We recommend enabling annotation processing in your IDE https://immutables.github.io/apt.html.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -66,48 +66,46 @@ After this initial setup development in Eclipse should be reasonably straight fo
 
 ### Set up Api Client
 
-```javascript
-String SERVICE_PLAN_ID = "SERVICE_PLAN_ID";
-String TOKEN = "SERVICE_TOKEN";
+```java
 ApiConnection conn =
-        ApiConnection.builder()
-            .servicePlanId(SERVICE_PLAN_ID)
-            .token(TOKEN)
-            .start()
+    ApiConnection.builder()
+        .servicePlanId("SERVICE_PLAN_ID")
+        .token("SERVICE_TOKEN")
+        .start();
 ```
 
 #### Sending Text Message
 
-```javascript
-String SENDER = "SENDER"; // Optional
-String [] RECIPIENTS = {"1232323131", "3213123"}  ;
+```java
+String sender = "SENDER"; // Optional, must be valid phone number, short code or alphanumeric.
+String [] recipients = {"1232323131", "3213123"};
 MtBatchTextSmsResult batch =
-          conn.createBatch(
-              SinchSMSApi.batchTextSms()
-                  .sender(SENDER)
-                  .addRecipient(RECIPIENTS)
-                  .body("Something good")
-                  .build()
+conn.createBatch(
+    SinchSMSApi.batchTextSms()
+        .sender(sender)
+        .addRecipient(recipients)
+        .body("Something good")
+        .build());
 ```
 
 #### Sending Group Message
 
-```javascript
-      // Creating simple Group
-      GroupResult group = conn.createGroup(SinchSMSApi.groupCreate().name("Subscriber").build());
+```java
+// Creating simple Group
+GroupResult group = conn.createGroup(SinchSMSApi.groupCreate().name("Subscriber").build());
 
-      // Adding members (numbers) into the group
-      conn.updateGroup(
-          group.id(), SinchSMSApi.groupUpdate().addMemberInsertion("15418888", "323232").build());
+// Adding members (numbers) into the group
+conn.updateGroup(
+  group.id(), SinchSMSApi.groupUpdate().addMemberInsertion("15418888", "323232").build());
 
-      // Sending a message to the group
-      MtBatchTextSmsResult batch = conn.createBatch(
-          SinchSMSApi.batchTextSms()
-              .addRecipient(group.id().toString())
-              .body("Something good")
-              .build());
+// Sending a message to the group
+MtBatchTextSmsResult batch = conn.createBatch(
+  SinchSMSApi.batchTextSms()
+      .addRecipient(group.id().toString())
+      .body("Something good")
+      .build());
 
-      System.out.println("Successfully sent batch " + batch.id());
+System.out.println("Successfully sent batch " + batch.id());
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ API.
 
 ## Using
 
-To use this SDK, you can install them as follow
+To use this SDK, add it as a dependency
 
-With Maven
+Maven
 
 ```xml
 
@@ -22,10 +22,9 @@ With Maven
 </dependency>
 ```
 
-With Gradle
-
-```xml
-implementation 'com.sinch:sdk-sms:1.0.7'
+Gradle
+```groovy
+implementation 'com.sinch:sdk-sms:1.1.0'
 ```
 
 ## Building and installing

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ With Maven
 <dependency>
     <groupId>com.sinch</groupId>
     <artifactId>sdk-sms</artifactId>
-    <version>1.0.7</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,15 +23,6 @@
   <profiles>
     <profile>
       <id>internal-release</id>
-      <activation>
-        <property>
-          <name>useInternalRepo</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <properties>
-        <release.profile>internal-release</release.profile>
-      </properties>
       <distributionManagement>
         <repository>
           <id>clx-releases</id>
@@ -55,20 +46,20 @@
               <skipStaging>true</skipStaging>
             </configuration>
           </plugin>
+          <plugin>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>3.0.0-M6</version>
+            <configuration>
+              <tagNameFormat>@{project.version}-internal</tagNameFormat>
+              <releaseProfiles>internal-release</releaseProfiles>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>
 
     <profile>
       <id>public-release</id>
-      <activation>
-        <property>
-          <name>!useInternalRepo</name>
-        </property>
-      </activation>
-      <properties>
-        <release.profile>public-release</release.profile>
-      </properties>
       <distributionManagement>
         <repository>
           <id>ossrh</id>
@@ -81,6 +72,18 @@
           <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
       </distributionManagement>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-release-plugin</artifactId>
+            <version>3.0.0-M6</version>
+            <configuration>
+              <tagNameFormat>@{project.version}</tagNameFormat>
+              <releaseProfiles>public-release</releaseProfiles>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 
@@ -263,16 +266,6 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
-        <configuration>
-          <autoVersionSubmodules>true</autoVersionSubmodules>
-          <tagNameFormat>v@{project.version}</tagNameFormat>
-          <useReleaseProfile>true</useReleaseProfile>
-          <releaseProfiles>${release.profile}</releaseProfiles>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         </property>
       </activation>
       <properties>
+        <release.profile>internal-release</release.profile>
       </properties>
       <distributionManagement>
         <repository>
@@ -66,6 +67,7 @@
         </property>
       </activation>
       <properties>
+        <release.profile>public-release</release.profile>
       </properties>
       <distributionManagement>
         <repository>
@@ -270,7 +272,7 @@
           <autoVersionSubmodules>true</autoVersionSubmodules>
           <tagNameFormat>v@{project.version}</tagNameFormat>
           <useReleaseProfile>true</useReleaseProfile>
-          <releaseProfiles>internal-release</releaseProfiles>
+          <releaseProfiles>${release.profile}</releaseProfiles>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>maven-release-plugin</artifactId>
             <version>3.0.0-M6</version>
             <configuration>
-              <tagNameFormat>@{project.version}-internal</tagNameFormat>
+              <tagNameFormat>v@{project.version}-internal</tagNameFormat>
               <releaseProfiles>internal-release</releaseProfiles>
             </configuration>
           </plugin>
@@ -78,7 +78,7 @@
             <artifactId>maven-release-plugin</artifactId>
             <version>3.0.0-M6</version>
             <configuration>
-              <tagNameFormat>@{project.version}</tagNameFormat>
+              <tagNameFormat>v@{project.version}</tagNameFormat>
               <releaseProfiles>public-release</releaseProfiles>
             </configuration>
           </plugin>

--- a/release.sh
+++ b/release.sh
@@ -27,11 +27,13 @@ shift "$((OPTIND -1))"
 
 if [ "$INTERNAL_RELEASE" = true ] ; then
   echo "Making internal release"
+  TAG="@{project.artifactId}-internal"
 else
   echo "Making public release"
+  TAG="@{project.artifactId}"
 fi
 
 # Make release
 mvn release:clean
-mvn release:prepare --batch-mode "-Darguments=-DskipTests -Ddependency-check.skip=true"
+mvn -DtagNameFormat="$TAG" release:prepare --batch-mode "-Darguments=-DskipTests -Ddependency-check.skip=true"
 mvn release:perform "-Darguments=-DskipTests -DuseInternalRepo=${INTERNAL_RELEASE}"

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -exu
+set -eu
 
 INTERNAL_RELEASE=true
 
@@ -35,5 +35,5 @@ fi
 
 # Make release
 mvn release:clean
-mvn -DdryRun=true -P $PROFILE release:prepare --batch-mode "-Darguments=-DskipTests -Ddependency-check.skip=true"
-mvn -DdryRun=true -P $PROFILE release:perform "-Darguments=-DskipTests"
+mvn -P $PROFILE release:prepare --batch-mode "-Darguments=-DskipTests -Ddependency-check.skip=true"
+mvn -P $PROFILE release:perform "-Darguments=-DskipTests"

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eu
+set -exu
 
 INTERNAL_RELEASE=true
 
@@ -27,13 +27,13 @@ shift "$((OPTIND -1))"
 
 if [ "$INTERNAL_RELEASE" = true ] ; then
   echo "Making internal release"
-  TAG="@{project.artifactId}-internal"
+  PROFILE="internal-release"
 else
   echo "Making public release"
-  TAG="@{project.artifactId}"
+  PROFILE="public-release"
 fi
 
 # Make release
 mvn release:clean
-mvn -DtagNameFormat="$TAG" release:prepare --batch-mode "-Darguments=-DskipTests -Ddependency-check.skip=true"
-mvn release:perform "-Darguments=-DskipTests -DuseInternalRepo=${INTERNAL_RELEASE}"
+mvn -DdryRun=true -P $PROFILE release:prepare --batch-mode "-Darguments=-DskipTests -Ddependency-check.skip=true"
+mvn -DdryRun=true -P $PROFILE release:perform "-Darguments=-DskipTests"


### PR DESCRIPTION
Problems
- The git tag was conflicting between an internal and public release before.
- Read me contains `javascript` annotations, the example for sending an sms does not compile.
- `<releaseProfile>` was locked to `internal-release`. Unnecessary and deprecated`useReleaseProfile` was used.
- useInternalRepo flag didn't work on windows

Solution
- When doing an internal release, `-internal` will be added as a suffix to the git tag.
- Clean up README
- Use different release profile and `tagNameFormat` depending on profile. Delete `useReleaseProfile`.
- Use profiles instead of `useInternalRepo` flag