### PR TITLE
Remove double encoding of the service plan id for requests. Add parsi…

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify -Dgpg.skip
       - run: mkdir snapshots && cp target/*.jar snapshots
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Package
           path: snapshots

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.43.0</version>
+        <version>2.12.0</version>
         <configuration>
           <java>
             <googleJavaFormat />

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.12.0</version>
+        <version>2.43.0</version>
         <configuration>
           <java>
             <googleJavaFormat />

--- a/src/main/java/com/sinch/xms/ApiConnection.java
+++ b/src/main/java/com/sinch/xms/ApiConnection.java
@@ -51,10 +51,8 @@ import com.sinch.xms.api.Tags;
 import com.sinch.xms.api.TagsUpdate;
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -313,19 +311,15 @@ public abstract class ApiConnection implements Closeable {
   @Nonnull
   private URI endpoint(@Nonnull String subPath, @Nonnull List<NameValuePair> params) {
     try {
-      String spid = URLEncoder.encode(servicePlanId(), "UTF-8");
-      String path = endpoint().getPath() + "/v1/" + spid + subPath;
+      String path = endpoint().getPath() + "/v1/" + servicePlanId() + subPath;
       URIBuilder uriBuilder = new URIBuilder(endpoint()).setPath(path);
 
       if (!params.isEmpty()) {
         uriBuilder.setParameters(params);
       }
-
       return uriBuilder.build();
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException(e);
-    } catch (UnsupportedEncodingException e) {
-      throw new IllegalStateException(e);
     }
   }
 

--- a/src/main/java/com/sinch/xms/BadRequestResponseException.java
+++ b/src/main/java/com/sinch/xms/BadRequestResponseException.java
@@ -22,8 +22,8 @@ package com.sinch.xms;
 import com.sinch.xms.api.BadRequestError;
 
 /**
- * Exception representing a non api error response from XMS. This exception is thrown when some fundamental
- * contract of the XMS API has been broken.
+ * Exception representing a non api error response from XMS. This exception is thrown when some
+ * fundamental contract of the XMS API has been broken.
  *
  * <p>For information about specific errors please refer to the <a href=
  * "https://developers.sinch.com/docs/sms/api-reference/status-codes/">XMS API documentation</a>.

--- a/src/main/java/com/sinch/xms/BadRequestResponseException.java
+++ b/src/main/java/com/sinch/xms/BadRequestResponseException.java
@@ -1,0 +1,84 @@
+/*-
+ * #%L
+ * SDK for Sinch SMS
+ * %%
+ * Copyright (C) 2016 Sinch
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.sinch.xms;
+
+import com.sinch.xms.api.BadRequestError;
+
+/**
+ * Exception representing a non api error response from XMS. This exception is thrown when some fundamental
+ * contract of the XMS API has been broken.
+ *
+ * <p>For information about specific errors please refer to the <a href=
+ * "https://developers.sinch.com/docs/sms/api-reference/status-codes/">XMS API documentation</a>.
+ */
+public class BadRequestResponseException extends ApiException {
+
+  private static final long serialVersionUID = 1L;
+
+  private final Integer status;
+  private final String path;
+  private final String timestamp;
+  private final String error;
+
+  BadRequestResponseException(BadRequestError error) {
+    super(error.path());
+
+    this.status = error.status();
+    this.path = error.path();
+    this.timestamp = error.timestamp();
+    this.error = error.error();
+  }
+
+  /**
+   * The machine readable HTTP status code.
+   *
+   * @return the status code.
+   */
+  public Integer getStatus() {
+    return status;
+  }
+
+  /**
+   * The path of the request.
+   *
+   * @return the path text
+   */
+  public String getPath() {
+    return path;
+  }
+
+  /**
+   * The timestamp of the error.
+   *
+   * @return the timestamp as a string.
+   */
+  public String getTimestamp() {
+    return timestamp;
+  }
+
+  /**
+   * The human readable HTTP error text for the status.
+   *
+   * @return the error text
+   */
+  public String getError() {
+    return error;
+  }
+}

--- a/src/main/java/com/sinch/xms/EmptyAsyncConsumer.java
+++ b/src/main/java/com/sinch/xms/EmptyAsyncConsumer.java
@@ -20,7 +20,9 @@
 package com.sinch.xms;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.sinch.xms.api.ApiError;
+import com.sinch.xms.api.BadRequestError;
 import java.io.IOException;
 import java.nio.CharBuffer;
 import org.apache.http.HttpException;
@@ -82,8 +84,13 @@ class EmptyAsyncConsumer extends AsyncCharConsumer<Void> {
         return null;
       case HttpStatus.SC_BAD_REQUEST:
       case HttpStatus.SC_FORBIDDEN:
-        ApiError error = json.readValue(content, ApiError.class);
-        throw new ErrorResponseException(error);
+        try {
+          ApiError error = json.readValue(content, ApiError.class);
+          throw new ErrorResponseException(error);
+        } catch (ValueInstantiationException e) {
+          BadRequestError error = json.readValue(content, BadRequestError.class);
+          throw new BadRequestResponseException(error);
+        }
       case HttpStatus.SC_NOT_FOUND:
         HttpCoreContext coreContext = HttpCoreContext.adapt(context);
         RequestLine rl = coreContext.getRequest().getRequestLine();

--- a/src/main/java/com/sinch/xms/Utils.java
+++ b/src/main/java/com/sinch/xms/Utils.java
@@ -106,11 +106,8 @@ public final class Utils {
    * @throws NotFoundException if the desired resource was not found
    */
   static ConcurrentException unwrapExecutionException(ExecutionException e)
-      throws ErrorResponseException,
-          UnexpectedResponseException,
-          UnauthorizedException,
-          NotFoundException,
-          BadRequestResponseException {
+      throws ErrorResponseException, UnexpectedResponseException, UnauthorizedException,
+          NotFoundException, BadRequestResponseException {
     if (e.getCause() instanceof RuntimeException) {
       throw (RuntimeException) e.getCause();
     } else if (e.getCause() instanceof Error) {

--- a/src/main/java/com/sinch/xms/Utils.java
+++ b/src/main/java/com/sinch/xms/Utils.java
@@ -106,14 +106,19 @@ public final class Utils {
    * @throws NotFoundException if the desired resource was not found
    */
   static ConcurrentException unwrapExecutionException(ExecutionException e)
-      throws ErrorResponseException, UnexpectedResponseException, UnauthorizedException,
-          NotFoundException {
+      throws ErrorResponseException,
+          UnexpectedResponseException,
+          UnauthorizedException,
+          NotFoundException,
+          BadRequestResponseException {
     if (e.getCause() instanceof RuntimeException) {
       throw (RuntimeException) e.getCause();
     } else if (e.getCause() instanceof Error) {
       throw (Error) e.getCause();
     } else if (e.getCause() instanceof ErrorResponseException) {
       throw (ErrorResponseException) e.getCause();
+    } else if (e.getCause() instanceof BadRequestResponseException) {
+      throw (BadRequestResponseException) e.getCause();
     } else if (e.getCause() instanceof NotFoundException) {
       throw (NotFoundException) e.getCause();
     } else if (e.getCause() instanceof UnexpectedResponseException) {

--- a/src/main/java/com/sinch/xms/api/BadRequestError.java
+++ b/src/main/java/com/sinch/xms/api/BadRequestError.java
@@ -1,0 +1,78 @@
+/*-
+ * #%L
+ * SDK for Sinch SMS
+ * %%
+ * Copyright (C) 2016 Sinch
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.sinch.xms.api;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.sinch.xms.BadRequestResponseException;
+import javax.annotation.Nonnull;
+import org.immutables.value.Value;
+
+/**
+ * API object containing an error response.
+ *
+ * @see BadRequestResponseException
+ */
+@Value.Immutable
+@ValueStylePackageDirect
+@JsonDeserialize(as = BadRequestErrorImpl.class)
+public abstract class BadRequestError {
+
+  /**
+   * The timestamp of the error.
+   *
+   * @return a non-null string
+   */
+  public abstract String timestamp();
+
+  /**
+   * The machine readable HTTP status code.
+   *
+   * @return a non-null integer
+   */
+  public abstract Integer status();
+
+  /**
+   * The human readable HTTP error text for the status.
+   *
+   * @return a non-null string
+   */
+  public abstract String error();
+
+  /**
+   * The path of the request.
+   *
+   * @return a non-null string
+   */
+  public abstract String path();
+
+  /**
+   * Creates a new bad request error object from the given timestamp, status, error and path.
+   *
+   * @param timestamp the timestamp of the error
+   * @param status the status code
+   * @param error the error message
+   * @param path the path
+   * @return a non-null Bad request error object
+   */
+  @Nonnull
+  public static BadRequestError of(String timestamp, Integer status, String error, String path) {
+    return BadRequestErrorImpl.of(timestamp, status, error, path);
+  }
+}

--- a/src/main/java/com/sinch/xms/api/MoMmsBody.java
+++ b/src/main/java/com/sinch/xms/api/MoMmsBody.java
@@ -56,6 +56,7 @@ public abstract class MoMmsBody {
    */
   @Nullable
   public abstract String subject();
+
   /**
    * The textual message body, if available.
    *
@@ -63,6 +64,7 @@ public abstract class MoMmsBody {
    */
   @Nullable
   public abstract String message();
+
   /**
    * The list of attached media.
    *

--- a/src/main/java/com/sinch/xms/api/MoMmsMedia.java
+++ b/src/main/java/com/sinch/xms/api/MoMmsMedia.java
@@ -56,6 +56,7 @@ public abstract class MoMmsMedia {
    */
   @Nullable
   public abstract String url();
+
   /**
    * The content type of provided media. For example, 'image/jpeg'
    *
@@ -67,6 +68,7 @@ public abstract class MoMmsMedia {
   @Nonnull
   @JsonProperty("content_type")
   public abstract String contentType();
+
   /**
    * The status received while media upload to storage. Possible values are: Uploaded or Failed.
    *
@@ -74,6 +76,7 @@ public abstract class MoMmsMedia {
    */
   @Nonnull
   public abstract MediaStatus status();
+
   /**
    * Error code in case of failure or 0 for success.
    *


### PR DESCRIPTION
…ng for generic bad request responses which are not covered by regular ApiErrors.