### PR TITLE
Improved coverage of property tests

### DIFF
--- a/src/test/java/com/sinch/xms/BatchFilterTest.java
+++ b/src/test/java/com/sinch/xms/BatchFilterTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
 
 import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.generator.InRange;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -101,15 +102,15 @@ public class BatchFilterTest {
     assumeThat(senders, not(hasItem(containsString(","))));
     assumeThat(tags, not(hasItem(containsString(","))));
 
-    BatchFilter filter =
+    BatchFilter.Builder builder =
         SinchSMSApi.batchFilter()
-            .pageSize(pageSize)
             .senders(senders)
             .tags(tags)
             .startDate(startDate)
             .endDate(endDate)
-            .clientReference(clientReference)
-            .build();
+            .clientReference(clientReference);
+
+    BatchFilter filter = (senders.isEmpty()) ? builder.build() : builder.pageSize(pageSize).build();
 
     List<NameValuePair> params = filter.toQueryParams(page);
 

--- a/src/test/java/com/sinch/xms/DeliveryReportFilterTest.java
+++ b/src/test/java/com/sinch/xms/DeliveryReportFilterTest.java
@@ -81,15 +81,15 @@ public class DeliveryReportFilterTest {
       String clientReference)
       throws Exception {
 
-    DeliveryReportFilter filter =
+    DeliveryReportFilter.Builder builder =
         SinchSMSApi.deliveryReportFilter()
-            .pageSize(pageSize)
             .statuses(statuses)
             .codes(codes)
             .startDate(startDate)
             .endDate(endDate)
-            .clientReference(clientReference)
-            .build();
+            .clientReference(clientReference);
+
+    DeliveryReportFilter filter = (codes.isEmpty()) ? builder.build() : builder.pageSize(pageSize).build();
 
     List<NameValuePair> params = filter.toQueryParams(page);
 

--- a/src/test/java/com/sinch/xms/GroupFilterTest.java
+++ b/src/test/java/com/sinch/xms/GroupFilterTest.java
@@ -73,7 +73,9 @@ public class GroupFilterTest {
     // Constrain `tags` to strings not containing ','
     assumeThat(tags, not(hasItem(containsString(","))));
 
-    GroupFilter filter = SinchSMSApi.groupFilter().pageSize(pageSize).tags(tags).build();
+    GroupFilter.Builder builder = SinchSMSApi.groupFilter().tags(tags);
+
+    GroupFilter filter = (tags.isEmpty()) ? builder.build() : builder.pageSize(pageSize).build();
 
     List<NameValuePair> params = filter.toQueryParams(page);
 

--- a/src/test/java/com/sinch/xms/InboundsFilterTest.java
+++ b/src/test/java/com/sinch/xms/InboundsFilterTest.java
@@ -90,14 +90,14 @@ public class InboundsFilterTest {
     // Constrain `to` to strings not containing ','
     assumeThat(to, not(hasItem(containsString(","))));
 
-    InboundsFilter filter =
+    InboundsFilter.Builder builder =
         SinchSMSApi.inboundsFilter()
-            .pageSize(pageSize)
             .recipients(to)
             .startDate(startDate)
             .endDate(endDate)
-            .clientReference(clientReference)
-            .build();
+            .clientReference(clientReference);
+
+    InboundsFilter filter = (to.isEmpty()) ? builder.build() : builder.pageSize(pageSize).build();
 
     List<NameValuePair> params = filter.toQueryParams(page);
 


### PR DESCRIPTION
Hi!

We are trying to increase the coverage of property tests for Java programs, and we found a way to do so in your project.
When using builders, not providing a page size allows to reach more code than always providing a page size.
As such, this PR changes the property tests so that sometimes they don't provide a page size to the builder, thus reaching more code.

For instance, on `BatchFilterTest.generatesValidQueryParameters`, not providing a page size causes the constructor on `BatchFilterImpl` to reach method `BatchFilter.pageSize`, which otherwise would not be reached by this test.
The argument for all the other tests is similar.